### PR TITLE
Improve build workflow

### DIFF
--- a/.github/workflows/build-spec.yml
+++ b/.github/workflows/build-spec.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
 
@@ -48,7 +48,7 @@ jobs:
         cp docs/images/* build/images
 
     - name: Create ZIP archive
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: MIC-Core-Specification
         path: build/*

--- a/.github/workflows/build-spec.yml
+++ b/.github/workflows/build-spec.yml
@@ -10,12 +10,6 @@ on:
     branches:
       - 'main'
 
-permissions:
-  contents: read
-  actions: read
-  pages: write
-  id-token: write
-
 concurrency:
   group: "pages"
   cancel-in-progress: false
@@ -23,9 +17,6 @@ concurrency:
 jobs:
   
   generate-html:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-24.04
     steps:
 
@@ -77,7 +68,18 @@ jobs:
       if: github.ref == 'refs/heads/main' && github.event_name == 'push'
       uses: actions/upload-pages-artifact@v4
 
+  publish-html:
+    needs: generate-html
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-24.04
+    steps:
+
     - name: Deploy to Github Pages
-      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
       id: deployment
       uses: actions/deploy-pages@v4


### PR DESCRIPTION
Allow non-privileged runs to complete properly, only require higher permissions for runs that actually publish to pages.